### PR TITLE
Use hubot to create ping message

### DIFF
--- a/lib/actions/action-integration-statuspage-import-incident.ts
+++ b/lib/actions/action-integration-statuspage-import-incident.ts
@@ -289,6 +289,16 @@ const handler: ActionDefinition['handler'] = async (
 			},
 		);
 
+		// Actor to create ping message with
+		let actor = request.actor;
+		const hubot = await context.getCardBySlug(
+			context.privilegedSession,
+			'user-hubot@1.0.0',
+		);
+		if (hubot) {
+			actor = hubot.id;
+		}
+
 		// Add message with ping to incident timeline
 		await context.insertCard(
 			session,
@@ -299,7 +309,7 @@ const handler: ActionDefinition['handler'] = async (
 			},
 			{
 				data: {
-					actor: request.actor,
+					actor,
 					context: request.logContext,
 					action: 'action-create-event@1.0.0',
 					card: incident.id,

--- a/test/integration/actions/action-integration-statuspage-import-incident.spec.ts
+++ b/test/integration/actions/action-integration-statuspage-import-incident.spec.ts
@@ -6,11 +6,13 @@ import { IncidentContract, incidentsPlugin } from '../../../lib';
 import { STATUSPAGE_ENDPOINT } from '../../../lib/actions/action-integration-statuspage-import-incident';
 
 let ctx: testUtils.TestContext;
+let hubotUser: any;
 
 beforeAll(async () => {
 	ctx = await testUtils.newContext({
 		plugins: [incidentsPlugin()],
 	});
+	hubotUser = await ctx.createUser('hubot');
 	nock.cleanAll();
 });
 
@@ -155,8 +157,11 @@ describe('action-integration-statuspage-import-incident', () => {
 				},
 				data: {
 					type: 'object',
-					required: ['payload'],
+					required: ['actor', 'payload'],
 					properties: {
+						actor: {
+							const: hubotUser.id,
+						},
 						payload: {
 							type: 'object',
 							required: ['message'],


### PR DESCRIPTION
Use the hubot user as the actor to create the ping message on new
incidents. Fall back to the previously used request.actor if necessary.
The only issue with request.actor is that it will be the admin user
which displays as Loading... in the UI.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>