### PR TITLE
Improve incident names

### DIFF
--- a/lib/contracts/statuspage.ts
+++ b/lib/contracts/statuspage.ts
@@ -14,9 +14,6 @@ export const statuspage: ContractDefinition = {
 					type: 'object',
 					required: ['subdomain'],
 					properties: {
-						name: {
-							type: 'string',
-						},
 						description: {
 							type: 'string',
 						},

--- a/lib/types/contracts/statuspage.ts
+++ b/lib/types/contracts/statuspage.ts
@@ -9,7 +9,6 @@
 import type { Contract, ContractDefinition } from 'autumndb';
 
 export interface StatuspageData {
-	name?: string;
 	description?: string;
 	domain?: string;
 	subdomain: string;

--- a/test/integration/actions/action-integration-statuspage-import-incident.spec.ts
+++ b/test/integration/actions/action-integration-statuspage-import-incident.spec.ts
@@ -27,7 +27,7 @@ afterAll(async () => {
 
 describe('action-integration-statuspage-import-incident', () => {
 	describe('incident update webhooks', () => {
-		test.only('should upsert statuspage and incident contracts', async () => {
+		test('should upsert statuspage and incident contracts', async () => {
 			// Nock page and incident details
 			const data = {
 				page: {
@@ -78,20 +78,20 @@ describe('action-integration-statuspage-import-incident', () => {
 			await ctx.flushAll(ctx.session);
 
 			// Assert the statuspage contract was created
-			await ctx.waitForMatch({
+			const statuspage = await ctx.waitForMatch({
 				type: 'object',
-				required: ['type', 'data'],
+				required: ['type', 'name', 'data'],
 				properties: {
 					type: {
 						const: 'statuspage@1.0.0',
 					},
+					name: {
+						const: data.page.name,
+					},
 					data: {
 						type: 'object',
-						required: ['name', 'domain', 'subdomain', 'mirrors', 'description'],
+						required: ['domain', 'subdomain', 'mirrors', 'description'],
 						properties: {
-							name: {
-								const: data.page.name,
-							},
 							domain: {
 								const: data.page.domain,
 							},
@@ -121,7 +121,7 @@ describe('action-integration-statuspage-import-incident', () => {
 						const: 'incident@1.0.0',
 					},
 					name: {
-						const: data.incident.name,
+						const: `${statuspage.name} - ${data.incident.name}`,
 					},
 					data: {
 						type: 'object',
@@ -296,20 +296,20 @@ describe('action-integration-statuspage-import-incident', () => {
 			await ctx.flushAll(ctx.session);
 
 			// Assert the statuspage contract was created
-			await ctx.waitForMatch({
+			const statuspage = await ctx.waitForMatch({
 				type: 'object',
 				required: ['type', 'data'],
 				properties: {
 					type: {
 						const: 'statuspage@1.0.0',
 					},
+					name: {
+						const: data.page.name,
+					},
 					data: {
 						type: 'object',
-						required: ['name', 'domain', 'subdomain', 'mirrors', 'description'],
+						required: ['domain', 'subdomain', 'mirrors', 'description'],
 						properties: {
-							name: {
-								const: data.page.name,
-							},
 							domain: {
 								const: data.page.domain,
 							},
@@ -339,7 +339,7 @@ describe('action-integration-statuspage-import-incident', () => {
 						const: 'incident@1.0.0',
 					},
 					name: {
-						const: data.component.name,
+						const: `${statuspage.name} - ${data.component.name}: ${data.component.status}`,
 					},
 					data: {
 						type: 'object',

--- a/test/unit/actions/action-integration-statuspage-import-incident.spec.ts
+++ b/test/unit/actions/action-integration-statuspage-import-incident.spec.ts
@@ -3,8 +3,8 @@ import nock from 'nock';
 import {
 	getStatus,
 	STATUSPAGE_ENDPOINT,
-	validateComponentWebhook,
-	validateIncidentWebhook,
+	validateComponentUpdate,
+	validateIncidentUpdate,
 } from '../../../lib/actions/action-integration-statuspage-import-incident';
 
 const mock = {
@@ -42,8 +42,8 @@ describe('getStatus()', () => {
 	});
 });
 
-describe('validateComponentWebhook()', () => {
-	beforeAll(() => {
+describe('validateComponentUpdate()', () => {
+	test('should throw on invalid incident webhook', async () => {
 		// Nock page and incident details
 		nock.cleanAll();
 		nock(STATUSPAGE_ENDPOINT)
@@ -51,44 +51,9 @@ describe('validateComponentWebhook()', () => {
 			.reply(200, mock.page)
 			.get(`/pages/${mock.page.id}/components/${mock.component.id}`)
 			.reply(200, mock.component);
-	});
 
-	afterEach(() => {
-		nock.cleanAll();
-	});
-
-	test('should not throw on valid component webhook', async () => {
-		await validateComponentWebhook({
-			page: {
-				id: mock.page.id,
-				status_description: mock.page.status_description,
-			},
-			component: {
-				id: mock.component.id,
-				status: mock.component.status,
-				name: mock.component.name,
-			},
-		});
-	});
-
-	test('should not throw on incident webhook', async () => {
-		await validateComponentWebhook({
-			page: {
-				id: mock.page.id,
-				status_description: mock.page.status_description,
-			},
-			incident: {
-				id: mock.incident.id,
-				status: mock.incident.status,
-				impact: mock.incident.impact,
-				name: mock.incident.name,
-			},
-		});
-	});
-
-	test('should throw on invalid incident webhook', async () => {
 		await expect(
-			validateComponentWebhook({
+			validateComponentUpdate({
 				page: {
 					id: mock.page.id,
 					status_description: mock.page.status_description,
@@ -100,11 +65,13 @@ describe('validateComponentWebhook()', () => {
 				},
 			}),
 		).rejects.toThrow();
+
+		nock.cleanAll();
 	});
 });
 
-describe('validateIncidentWebhook()', () => {
-	beforeAll(() => {
+describe('validateIncidentUpdate()', () => {
+	test('should throw on invalid incident webhook', async () => {
 		// Nock page and incident details
 		nock.cleanAll();
 		nock(STATUSPAGE_ENDPOINT)
@@ -112,44 +79,9 @@ describe('validateIncidentWebhook()', () => {
 			.reply(200, mock.page)
 			.get(`/pages/${mock.page.id}/incidents/${mock.incident.id}`)
 			.reply(200, mock.incident);
-	});
 
-	afterEach(() => {
-		nock.cleanAll();
-	});
-
-	test('should not throw on valid incident webhook', async () => {
-		await validateIncidentWebhook({
-			page: {
-				id: mock.page.id,
-				status_description: mock.page.status_description,
-			},
-			incident: {
-				id: mock.incident.id,
-				status: mock.incident.status,
-				impact: mock.incident.impact,
-				name: mock.incident.name,
-			},
-		});
-	});
-
-	test('should not throw on component webhook', async () => {
-		await validateIncidentWebhook({
-			page: {
-				id: mock.page.id,
-				status_description: mock.page.status_description,
-			},
-			component: {
-				id: mock.component.id,
-				status: mock.component.status,
-				name: mock.component.name,
-			},
-		});
-	});
-
-	test('should throw on invalid incident webhook', async () => {
 		await expect(
-			validateIncidentWebhook({
+			validateIncidentUpdate({
 				page: {
 					id: mock.page.id,
 					status_description: mock.page.status_description,
@@ -162,5 +94,7 @@ describe('validateIncidentWebhook()', () => {
 				},
 			}),
 		).rejects.toThrow();
+
+		nock.cleanAll();
 	});
 });


### PR DESCRIPTION
Use root-level name instead of data.name for statuspage contracts.
Include statuspage name in incident contract name.
Improve logic flow when creating incident contracts from webhooks.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>